### PR TITLE
Added error pages handling

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -2,7 +2,8 @@
   "common_title": "unknown art",
   "common_menu" : {
     "home": "home",
-    "places": "places"
+    "places": "places",
+    "place": "place"
   },
   "common_language" : {
     "it": "italian",
@@ -54,6 +55,15 @@
       "reset": {
         "title": "reset",
         "label": "reset the search of places"
+      }
+    }
+  },
+  "common_error": {
+    "description": "the {{page}} page has some problem, you can visit us later, or try to reload the page.",
+    "action": {
+      "reload": {
+        "title": "reload",
+        "label": "reload the {{page}} page"
       }
     }
   },

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -2,7 +2,8 @@
   "common_title": "unknown art",
   "common_menu": {
     "home": "home",
-    "places": "posti"
+    "places": "posti",
+    "place": "posto"
   },
   "common_language": {
     "it": "italiano",
@@ -54,6 +55,15 @@
       "reset": {
         "title": "resetta",
         "label": "resetta la ricerca di posti"
+      }
+    }
+  },
+  "common_error": {
+    "description": "la pagina {page} ha qualche problema, puoi visitarci tra un po', oppure prova a ricaricare la pagina.",
+    "action": {
+      "reload": {
+        "title": "ricarica",
+        "label": "ricarica la pagina {page}"
       }
     }
   },

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import type { Metadata } from 'next/types'
+import { useCallback } from 'react'
+
+import { ErrorContent } from 'src/components/error-content'
+import { useTranslationClient } from 'src/helpers/hooks/useTranslationClient'
+import { ComponentErrorParams } from 'src/types/component'
+
+
+type AppErrorProps = ComponentErrorParams
+
+export const metadata: Metadata = {
+  title: 'unknown art',
+}
+
+export default function AppError({ reset }: AppErrorProps) {
+  const params = useParams()
+  const locale = params.locale as string
+
+  const { t } = useTranslationClient({ locale, namespace: 'translation' })
+  const tPage = t('common_menu.home')
+
+  const onReset = useCallback(() => {
+    reset()
+  }, [reset])
+
+  return (<ErrorContent page={tPage} onReset={onReset} />)
+}

--- a/src/app/[locale]/places/[placeId]/error.tsx
+++ b/src/app/[locale]/places/[placeId]/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import type { Metadata } from 'next/types'
+import { useCallback } from 'react'
+
+import { ErrorContent } from 'src/components/error-content'
+import { useTranslationClient } from 'src/helpers/hooks/useTranslationClient'
+import { ComponentErrorParams } from 'src/types/component'
+
+
+type PlaceErrorProps = ComponentErrorParams
+
+export const metadata: Metadata = {
+  title: 'unknown art',
+}
+
+export default function PlaceError({ reset }: PlaceErrorProps) {
+  const params = useParams()
+  const locale = params.locale as string
+
+  const { t } = useTranslationClient({ locale, namespace: 'translation' })
+  const tPage = t('common_menu.place')
+
+  const onReset = useCallback(() => {
+    reset()
+  }, [reset])
+
+  return (<ErrorContent page={tPage} onReset={onReset} />)
+}

--- a/src/app/[locale]/places/error.tsx
+++ b/src/app/[locale]/places/error.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import type { Metadata } from 'next/types'
+import { useCallback } from 'react'
+
+import { ErrorContent } from 'src/components/error-content'
+import { useTranslationClient } from 'src/helpers/hooks/useTranslationClient'
+import { ComponentErrorParams } from 'src/types/component'
+
+
+type PlacesErrorProps = ComponentErrorParams
+
+export const metadata: Metadata = {
+  title: 'unknown art',
+}
+
+export default function PlacesError({ reset }: PlacesErrorProps) {
+  const params = useParams()
+  const locale = params.locale as string
+
+  const { t } = useTranslationClient({ locale, namespace: 'translation' })
+  const tPage = t('common_menu.places')
+
+  const onReset = useCallback(() => {
+    reset()
+  }, [reset])
+
+  return (<ErrorContent page={tPage} onReset={onReset} />)
+}

--- a/src/components/error-content/error-content.tsx
+++ b/src/components/error-content/error-content.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { memo } from 'react'
+import type { FC } from 'react'
+
+import { useTranslationClient } from 'src/helpers/hooks/useTranslationClient'
+import { ComponentErrorParams } from 'src/types/component'
+
+
+type ErrorContentProps = {
+  page: string
+  onReset: ComponentErrorParams['reset']
+}
+
+export const ErrorContent: FC<ErrorContentProps> = memo(({ page, onReset }) => {
+  const params = useParams()
+  const locale = params.locale as string
+
+  const { t } = useTranslationClient({ locale, namespace: 'translation' })
+
+  return (
+    <>
+      <h1>{t('common_title')}</h1>
+
+      <p>{t('common_error.description', { page })}</p>
+
+      <a
+        role="button"
+        aria-label={t('common_error.action.reload.label', { page })}
+        onClick={onReset}
+      >
+        {t('common_error.action.reload.title')}
+      </a>
+    </>
+  )
+})
+
+ErrorContent.displayName = 'ErrorContent'

--- a/src/components/error-content/index.ts
+++ b/src/components/error-content/index.ts
@@ -1,0 +1,1 @@
+export * from './error-content'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,28 +14,30 @@ export const config = {
 /* eslint-enable */
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { cookies, headers, nextUrl, url } = request
+
   const response = NextResponse.next()
 
   let locale
-  if (request.cookies.has(I18N_COOKIE_NAME)) {
-    locale = acceptLanguage.get(request.cookies.get(I18N_COOKIE_NAME)?.value)
+  if (cookies.has(I18N_COOKIE_NAME)) {
+    locale = acceptLanguage.get(cookies.get(I18N_COOKIE_NAME)?.value)
   }
   if (!locale) {
-    locale = acceptLanguage.get(request.headers.get('Accept-Language'))
+    locale = acceptLanguage.get(headers.get('Accept-Language'))
   }
   if (!locale) {
     locale = defaultLocale
   }
 
   if (
-    !locales.some(loc => request.nextUrl.pathname.startsWith(`/${loc}`)) &&
-    !request.nextUrl.pathname.startsWith('/_next')
+    !locales.some(loc => nextUrl.pathname.startsWith(`/${loc}`)) &&
+    !nextUrl.pathname.startsWith('/_next')
   ) {
-    return NextResponse.redirect(new URL(`/${locale}${request.nextUrl.pathname}`, request.url))
+    return NextResponse.redirect(new URL(`/${locale}${nextUrl.pathname}`, url))
   }
 
-  if (request.headers.has('referer')) {
-    const referer = request.headers.get('referer')
+  if (headers.has('referer')) {
+    const referer = headers.get('referer')
 
     if (referer !== null) {
       const refererUrl = new URL(referer)

--- a/src/types/component.d.ts
+++ b/src/types/component.d.ts
@@ -3,3 +3,8 @@ export type ComponentParams = {
     locale: string
   }
 }
+
+export type ComponentErrorParams = {
+  error: Error & { digest?: string }
+  reset: () => void
+}


### PR DESCRIPTION
- [x] `home_error`, `places_error` and `place_error` could become `common_error` with page name as parameter to reduce repetition of code in translations
- [x] `errot.tsx`s have same layout, use a common Error content component to be imported

