### PR TITLE
Handled 404 pages

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -70,5 +70,8 @@
         "label": "reload the {{page}} page"
       }
     }
+  },
+  "notfound": {
+    "description": "the page is not found, visit the home page to solve the problem."
   }
 }

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -70,5 +70,8 @@
         "label": "ricarica la pagina {{page}}"
       }
     }
+  },
+  "notfound": {
+    "description": "la pagina non è stata trovata, visita la pagina home per risolvere il problema."
   }
 }

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next/types'
+
+import { NotFoundContentClient } from 'src/components/not-found-content'
+
+
+export const metadata: Metadata = {
+  title: 'unknown art',
+}
+
+export default function HomeNotFound() {
+  return (<NotFoundContentClient />)
+}

--- a/src/app/[locale]/places/[placeId]/page.tsx
+++ b/src/app/[locale]/places/[placeId]/page.tsx
@@ -1,6 +1,7 @@
 import fetchedMeta from 'fetch-meta-tags'
 import type { fetchedMeta as FetchedMetadata } from 'fetch-meta-tags'
 import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 
 import styles from './place.module.css'
 
@@ -21,9 +22,12 @@ type PlacePageProps = {
 
 type PlaceMeta = FetchedMetadata | null
 
-export async function generateMetadata({ params }: PlacePageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: PlacePageProps): Promise<Metadata | void> {
   const { t } = await getTranslationServer({ locale: params.locale, namespace: 'common' })
   const place = await getPlace(params.placeId)
+  if (place === null) {
+    return
+  }
 
   return {
     title: `${meta.siteName} _ ${t('menu.place')} _ ${place.name}`,
@@ -42,6 +46,9 @@ export default async function PlacePage({ params }: PlacePageProps) {
   const { t } = await getTranslationServer({ locale: params.locale, namespace: 'places' })
 
   const place = await getPlace(params.placeId)
+  if (place === null) {
+    notFound()
+  }
 
   let placeMeta: PlaceMeta
   try {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import 'src/styles/globals.css'
+import 'src/styles/reset.css'
+import type { ReactNode } from 'react'
+
+
+type AppLayoutProps = {
+  children: ReactNode
+}
+
+export default function AppLayout({ children }: AppLayoutProps) {
+  return children
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next/types'
+
+import { Analytics } from 'src/components/analytics'
+import { NotFoundContentServer } from 'src/components/not-found-content'
+import { font } from 'src/helpers/config/font'
+import { isEnvironmentProduction } from 'src/helpers/utils/isEnvironment'
+
+
+export const metadata: Metadata = {
+  title: 'unknown art',
+}
+
+export default function AppNotFound() {
+  const environment = process.env.NEXT_PUBLIC_NODE_ENV || 'development'
+
+  return (
+    <html>
+      <head />
+
+      {isEnvironmentProduction(environment) && (<Analytics />)}
+
+      <body className={font.className}>
+        <main>
+          <NotFoundContentServer />
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/src/components/not-found-content/index.ts
+++ b/src/components/not-found-content/index.ts
@@ -1,0 +1,2 @@
+export * from './not-found-content-client'
+export * from './not-found-content-server'

--- a/src/components/not-found-content/not-found-content-client.tsx
+++ b/src/components/not-found-content/not-found-content-client.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+import { useTranslationClient } from 'src/helpers/hooks/useTranslationClient'
+
+
+export const NotFoundContentClient = () => {
+  const params = useParams()
+  const locale = params.locale as string
+
+  const { t } = useTranslationClient({ locale, namespace: 'common' })
+
+  return (
+    <>
+      <h1>{t('title')}</h1>
+
+      <p>{t('notfound.description')}</p>
+    </>
+  )
+}

--- a/src/components/not-found-content/not-found-content-server.tsx
+++ b/src/components/not-found-content/not-found-content-server.tsx
@@ -1,0 +1,15 @@
+import { defaultLocale } from 'src/helpers/config/i18n'
+import { getTranslationServer } from 'src/helpers/utils/getTranslationServer'
+
+
+export const NotFoundContentServer = async () => {
+  const { t } = await getTranslationServer({ locale: defaultLocale, namespace: 'common' })
+
+  return (
+    <>
+      <h1>{t('title')}</h1>
+
+      <p>{t('notfound.description')}</p>
+    </>
+  )
+}


### PR DESCRIPTION
Todo:

- [x] Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>, in pages like URL/it/wrongpage
- [x] NotFound missing in URL/place/WRONGIDPLACE